### PR TITLE
[Feature] simplify `get_leafs()` and `construct_scorecard()` in `XGBScorecardConstructor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,22 +58,22 @@ X_train, X_test, y_train, y_test = train_test_split(
 
 # Train the XGBoost model
 best_params = {
-    'n_estimators': 100,
-    'learning_rate': 0.55,
-    'max_depth': 1,
-    'min_child_weight': 10,
-    'grow_policy': "lossguide",
-    'early_stopping_rounds': 5
+    "n_estimators": 100,
+    "learning_rate": 0.55,
+    "max_depth": 1,
+    "min_child_weight": 10,
+    "grow_policy": "lossguide",
+    "early_stopping_rounds": 5
 }
 model = xgb.XGBClassifier(**best_params, random_state=62)
-model.fit(X_train, y_train)
+model.fit(X_train, y_train, eval_set=[(X_test, y_test)])
 
 # Initialize XGBScorecardConstructor
 scorecard_constructor = XGBScorecardConstructor(model, X_train, y_train)
 scorecard_constructor.construct_scorecard()
 
 # Print the scorecard
-print(scorecard_constructor.scorecard)
+print(scorecard_constructor.xgb_scorecard)
 ```
 
 After this, we can create a scorecard and test its Gini score:


### PR DESCRIPTION
### Changes

- Simplify the `get_leafs()` and `construct_scorecard()` to improve clarity without logic changed.
- Minor README.md

## Summary by Sourcery

Simplify internal methods in XGBScorecardConstructor for clarity and update the README example

Enhancements:
- Refactor get_leafs to consolidate leaf index and margin predictions and eliminate branching
- Streamline construct_scorecard to reuse tree leaf indexes directly and remove redundant dataframes

Documentation:
- Adjust README formatting and add eval_set to model.fit example