### PR TITLE
[Refactor] make faster `construct_scorecard` method for `xbooster/lgb_constructor.py`

### DIFF
--- a/xbooster/lgb_constructor.py
+++ b/xbooster/lgb_constructor.py
@@ -293,10 +293,13 @@ class LGBScorecardConstructor:  # pylint: disable=R0902
                 f"Invalid leaf index shape {tree_leaf_idx.shape}. Expected {(len(labels), n_trees)}"
             )
 
-        df_long = pd.DataFrame(tree_leaf_idx).melt(var_name="Tree", value_name="Node")
-        df_long["label"] = np.tile(labels.values, tree_leaf_idx.shape[1])
+        # Aggregate indices, leafs, and counts of events and non-events
+        tree_leaf_idx_long = pd.DataFrame(tree_leaf_idx).melt(var_name="Tree", value_name="Node")
+        tree_leaf_idx_long["label"] = np.tile(labels.values, tree_leaf_idx.shape[1])
         binning_table = (
-            df_long.groupby(["Tree", "Node"])["label"].agg(["sum", "count"]).reset_index()
+            tree_leaf_idx_long.groupby(["Tree", "Node"])["label"]
+            .agg(["sum", "count"])
+            .reset_index()
         )
         binning_table.columns = ["Tree", "Node", "Events", "Count"]
         df_binning_table = binning_table.assign(


### PR DESCRIPTION
## Description

This PR optimizes the `construct_scorecard` method by replacing the iterative tree-by-tree processing with a vectorized approach using Pandas and NumPy.

Previously, the code used a Python loop to iterate through each tree, performing individual grouping and concatenation. This created significant overhead, especially as the number of trees increased. The new implementation leverages `melt()` and a single `groupby()` operation to process all trees simultaneously.

## Key Changes
- Eliminated Python Loops: Removed for i in range(n_trees) and replaced it with pd.DataFrame.melt().
- Efficient Data Tiling: Used np.tile() for high-performance expansion of labels across all tree iterations.
- Unified Aggregation: Consolidated the calculation of Events, NonEvents, and Count into a single, optimized groupby operation.

## Performance Benchmark
Measured using `%%timeit` on the example ipynb:

Method | Execution Time (Mean ± Std. Dev.) | Speedup
-- | -- | --
Original (Iterative) | 18.6 ms ± 277 μs | 1.0x
Improved (Vectorized) | 2.55 ms ± 132 μs | ~7x faster

## Summary by Sourcery

Optimize LightGBM scorecard construction by replacing per-tree looping with a vectorized aggregation over all trees and merging results directly on tree/node identifiers.

Enhancements:
- Vectorize scorecard binning table construction using a single melt/groupby over all trees instead of iterative per-tree processing.
- Simplify the merge between leaf weights and binning statistics by aligning on common Tree/Node keys and removing redundant columns.