### PR TITLE
[Refactor] make faster `_convert_tree_to_points` use np.vectorize instead of merge in `xbooster/lgb_constructor.py`

### DIFF
--- a/xbooster/lgb_constructor.py
+++ b/xbooster/lgb_constructor.py
@@ -504,7 +504,7 @@ class LGBScorecardConstructor:  # pylint: disable=R0902
             ]
             # Mapping dictionary instead of merge
             mapping_dict = dict(zip(tree_points["Node"], tree_points["Points"]))
-            points_matrix[:, t] = np.vectorize(mapping_dict.get)(leaf_idx_values[:, t])
+            points_matrix[:, t] = pd.Series(leaf_idx_values[:, t]).map(mapping_dict).to_numpy()
 
         result = pd.DataFrame(
             points_matrix, index=X.index, columns=[f"Score_{i}" for i in range(n_trees)]

--- a/xbooster/lgb_constructor.py
+++ b/xbooster/lgb_constructor.py
@@ -494,27 +494,23 @@ class LGBScorecardConstructor:  # pylint: disable=R0902
 
         # Get leaf indices for all trees
         X_leaf_indices = self.get_leafs(X, output_type="leaf_index")
-
-        result = pd.DataFrame()
-        for col in X_leaf_indices.columns:
-            tree_number = col.split("_")[1]
+        n_samples, n_trees = X_leaf_indices.shape
+        points_matrix = np.zeros((n_samples, n_trees))
+        leaf_idx_values = X_leaf_indices.values
+        for t in range(n_trees):
             # Get points for this tree
-            subset_points_df = self.lgb_scorecard_with_points[
-                self.lgb_scorecard_with_points["Tree"] == int(tree_number)
-            ].copy()
+            tree_points = self.lgb_scorecard_with_points[
+                self.lgb_scorecard_with_points["Tree"] == t
+            ]
+            # Mapping dictionary instead of merge
+            mapping_dict = dict(zip(tree_points["Node"], tree_points["Points"]))
+            points_matrix[:, t] = np.vectorize(mapping_dict.get)(leaf_idx_values[:, t])
 
-            # Merge leaf indices with points
-            merged_df = pd.merge(
-                X_leaf_indices[[col]].round(4),
-                subset_points_df[["Node", "Points"]],
-                left_on=col,
-                right_on="Node",
-                how="left",
-            )
-            result[f"Score_{tree_number}"] = merged_df["Points"]
-
+        result = pd.DataFrame(
+            points_matrix, index=X.index, columns=[f"Score_{i}" for i in range(n_trees)]
+        )
         # Add total score
-        result = pd.concat([result, result.sum(axis=1).rename("Score")], axis=1)
+        result["Score"] = points_matrix.sum(axis=1)
         return result
 
     def predict_score(self, X: pd.DataFrame) -> pd.Series:  # pylint: disable=C0103


### PR DESCRIPTION
## Description
This PR optimizes the scoring engine by replacing the inefficient iterative pd.merge operations with Vectorized Dictionary Mapping.

The previous implementation performed a `pd.merge` within a loop for every tree, which caused performance bottlenecks and memory overhead during the scoring of large datasets. The new approach pre-extracts leaf indices as a NumPy array and applies score mapping using `map`, resulting in a speedup.

## Key Changes
- Vectorized Lookup: Switched from iterative pd.merge to NumPy-based dictionary mapping.

## Performance Benchmark
Measured using `%%timeit` on the example ipynb:

Method | Execution Time (Mean ± Std. Dev.) | Speedup
-- | -- | --
Original (Iterative) | 11.6 ms ± 206 μs | 1.0x
Improved (Vectorized) | 2.71 ms ± 31.6 μs | ~4x faster

## Summary by Sourcery

Optimize tree-to-points conversion in the LightGBM constructor for faster score computation by replacing per-tree DataFrame merges with a vectorized mapping approach.

Enhancements:
- Replace per-tree pandas merge operations with a vectorized NumPy-based mapping from leaf indices to point scores to improve performance of score calculation.
- Construct score matrices directly from NumPy arrays and compute total scores via array summation instead of DataFrame concatenation.