### PR TITLE
[Refactor] faster `get_leafs` method for `xbooster/lgb_constructor.py`

### DIFF
--- a/xbooster/lgb_constructor.py
+++ b/xbooster/lgb_constructor.py
@@ -190,13 +190,12 @@ class LGBScorecardConstructor:  # pylint: disable=R0902
 
         # For margin output, get raw scores per tree
         # Each tree's prediction is returned as-is (no base_score adjustment needed)
-        df_leafs = pd.DataFrame()
-
+        tree_results = []
         for i in range(n_trees):
-            df_leafs[f"tree_{i}"] = self.model.predict(
-                X, raw_score=True, start_iteration=i, num_iteration=1
-            )
+            res = self.model.predict(X, raw_score=True, start_iteration=i, num_iteration=1)
+            tree_results.append(res)
 
+        df_leafs = pd.DataFrame(np.column_stack(tree_results), index=X.index, columns=_colnames)
         return df_leafs
 
     def extract_leaf_weights(self) -> pd.DataFrame:


### PR DESCRIPTION
## Description
This PR optimizes the `get_leafs` method (specifically for output_type="margin") by replacing iterative DataFrame column assignment with the Collect-then-Construct pattern using `np.column_stack`.

## Key Changes
- Switched from iterative column assignment (df[col] = value) to Collect-then-Construct pattern using `np.column_stack`.

## Performance Benchmark
Measured using `%%timeit` on the example ipynb:

Method | Execution Time (Mean ± Std. Dev.) | Speedup
-- | -- | --
Original (Iterative) | 6.24 ms ± 139 μs | 1.0x
Improved (Stacked) | 4.54 ms ± 44.3 μ | ~1.4x faster

## Summary by Sourcery

Enhancements:
- Replace iterative per-column DataFrame assignment with collection of per-tree prediction arrays and a single `np.column_stack`-based DataFrame construction to speed up margin leaf retrieval.