### PR TITLE
[Refactor] make `xgb_construct` fast 

### DIFF
--- a/tests/test_xgb_regression.py
+++ b/tests/test_xgb_regression.py
@@ -126,7 +126,7 @@ class TestXGBRegression:
         # Verify data types
         assert pd.api.types.is_integer_dtype(scorecard["Tree"])
         assert pd.api.types.is_integer_dtype(scorecard["Node"])
-        assert pd.api.types.is_float_dtype(scorecard["Count"])
+        assert pd.api.types.is_integer_dtype(scorecard["Count"])
         assert pd.api.types.is_float_dtype(scorecard["EventRate"])
 
     def test_construct_scorecard_statistical_properties(self, sample_data, trained_model):

--- a/xbooster/xgb_constructor.py
+++ b/xbooster/xgb_constructor.py
@@ -202,15 +202,14 @@ class XGBScorecardConstructor:
             # Predict leaf index
             tree_leaf_idx = self.booster_.predict(xgb_features, pred_leaf=True)
             return pd.DataFrame(tree_leaf_idx, columns=_colnames)
-
-        df_leafs = pd.DataFrame()
+        tree_results = []
         for i in range(n_rounds):
-            # Predict margin
             tree_leafs = (
                 self.booster_.predict(xgb_features, iteration_range=(i, i + 1), output_margin=True)
                 - scores
             )
-            df_leafs[f"tree_{i}"] = tree_leafs.flatten()
+            tree_results.append(tree_leafs.flatten())
+        df_leafs = pd.DataFrame(np.column_stack(tree_results), index=X.index, columns=_colnames)
         return df_leafs
 
     def extract_leaf_weights(self) -> pd.DataFrame:

--- a/xbooster/xgb_constructor.py
+++ b/xbooster/xgb_constructor.py
@@ -539,6 +539,10 @@ class XGBScorecardConstructor:
             pd.DataFrame: The DataFrame containing scores per tree and the total score.
 
         """
+        if self.xgb_scorecard_with_points is None:
+            raise ValueError(
+                "No scorecard with points has been created yet. Call create_points() first."
+            )
         X_leaf_weights = self.get_leafs(X, output_type="leaf_index")  # pylint: disable=C0103
         n_samples, n_rounds = X_leaf_weights.shape
         points_matrix = np.zeros((n_samples, n_rounds))

--- a/xbooster/xgb_constructor.py
+++ b/xbooster/xgb_constructor.py
@@ -554,7 +554,7 @@ class XGBScorecardConstructor:
             ]
             # Mapping dictionary instead of merge
             mapping_dict = dict(zip(tree_points["Node"], tree_points["Points"]))
-            points_matrix[:, t] = np.vectorize(mapping_dict.get)(leaf_idx_values[:, t])
+            points_matrix[:, t] = pd.Series(leaf_idx_values[:, t]).map(mapping_dict).to_numpy()
 
         result = pd.DataFrame(
             points_matrix, index=X.index, columns=[f"Score_{i}" for i in range(n_rounds)]


### PR DESCRIPTION
## Description
This PR optimizes the `xbooster/xgb_constructor.py`.

## Key Changes & Benchmarks
Similar to https://github.com/xRiskLab/xBooster/pull/10, https://github.com/xRiskLab/xBooster/pull/11, https://github.com/xRiskLab/xBooster/pull/13

## Summary by Sourcery

Optimize construction of XGBoost leaf outputs and scorecards for better performance and correctness.

Enhancements:
- Vectorize leaf prediction aggregation in get_leafs to avoid per-tree DataFrame concatenation.
- Refactor scorecard construction to use a single grouped aggregation over all tree/leaf indices instead of looping per tree.
- Replace per-column merge-based point calculation in _convert_tree_to_points with vectorized mapping using precomputed matrices.

Tests:
- Update regression test to assert that the scorecard Count column is stored as an integer type.