### PR TITLE
[Bugfix] set permissions to compatibility github action

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -81,6 +81,10 @@ jobs:
     needs: compatibility-test
     if: always()
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes to https://github.com/xRiskLab/xBooster/issues/12

Note on [GitHub Action Failure](https://github.com/xRiskLab/xBooster/actions/runs/20422724737/job/58677363706?pr=15#step:1:23): This is expected for now because the current base branch lacks the necessary permissions for Fork PRs. I have included the fix in this PR (permissions block), so it will work correctly starting from the next PR after this one is merged.


## Summary by Sourcery

CI:
- Grant the compatibility workflow job read access to repository contents and write access to pull requests.